### PR TITLE
Add Kanban Sections with Color Variations

### DIFF
--- a/src/features/kanban/components/board-column.tsx
+++ b/src/features/kanban/components/board-column.tsx
@@ -14,6 +14,7 @@ import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 export interface Column {
   id: UniqueIdentifier;
   title: string;
+  color?: string;
 }
 
 export type ColumnType = 'Column';
@@ -70,15 +71,28 @@ export function BoardColumn({ column, tasks, isOverlay }: BoardColumnProps) {
     }
   );
 
+  const columnColor = column.color || '#64748b'; // Default slate color if none provided
+
   return (
     <Card
       ref={setNodeRef}
-      style={style}
+      style={{
+        ...style,
+        borderTop: '4px solid',
+        borderColor: columnColor
+      }}
       className={variants({
         dragging: isOverlay ? 'overlay' : isDragging ? 'over' : undefined
       })}
     >
-      <CardHeader className='space-between flex flex-row items-center border-b-2 p-4 text-left font-semibold'>
+      <CardHeader 
+        className='space-between flex flex-row items-center p-4 text-left font-semibold'
+        style={{ 
+          borderBottom: '2px solid',
+          borderColor: columnColor,
+          position: 'relative'
+        }}
+      >
         <Button
           variant={'ghost'}
           {...attributes}
@@ -88,12 +102,11 @@ export function BoardColumn({ column, tasks, isOverlay }: BoardColumnProps) {
           <span className='sr-only'>{`Move column: ${column.title}`}</span>
           <IconGripVertical />
         </Button>
-        {/* <span className="mr-auto mt-0!"> {column.title}</span> */}
-        {/* <Input
-          defaultValue={column.title}
-          className="text-base mt-0! mr-auto"
-        /> */}
-        <ColumnActions id={column.id} title={column.title} />
+        <ColumnActions 
+          id={column.id} 
+          title={column.title}
+          color={column.color} 
+        />
       </CardHeader>
       <CardContent className='flex grow flex-col gap-4 overflow-x-hidden p-2'>
         <ScrollArea className='h-full'>

--- a/src/features/kanban/components/color-picker.tsx
+++ b/src/features/kanban/components/color-picker.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { cn } from '@/lib/utils';
+import { useCallback } from 'react';
+
+const predefinedColors = [
+  '#2563eb', // Blue
+  '#ca8a04', // Amber
+  '#16a34a', // Green
+  '#dc2626', // Red
+  '#7c3aed', // Violet
+  '#db2777', // Pink
+  '#ea580c', // Orange
+  '#0891b2', // Cyan
+  '#4b5563', // Gray
+  '#64748b', // Slate
+];
+
+interface ColorPickerProps {
+  selectedColor: string;
+  onColorChange: (color: string) => void;
+}
+
+export function ColorPicker({ selectedColor, onColorChange }: ColorPickerProps) {
+  const handleColorSelect = useCallback(
+    (color: string) => {
+      onColorChange(color);
+    },
+    [onColorChange]
+  );
+
+  return (
+    <div className="flex flex-wrap gap-2 mt-2">
+      {predefinedColors.map((color) => (
+        <button
+          key={color}
+          type="button"
+          className={cn(
+            'w-6 h-6 rounded-full cursor-pointer transition-all hover:scale-110',
+            selectedColor === color && 'ring-2 ring-offset-2'
+          )}
+          style={{ backgroundColor: color }}
+          onClick={() => handleColorSelect(color)}
+          aria-label={`Select color ${color}`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/features/kanban/components/column-action.tsx
+++ b/src/features/kanban/components/column-action.tsx
@@ -23,19 +23,24 @@ import { useTaskStore } from '../utils/store';
 import { UniqueIdentifier } from '@dnd-kit/core';
 import { Input } from '@/components/ui/input';
 import { toast } from 'sonner';
+import { ColorPicker } from './color-picker';
 
 export function ColumnActions({
   title,
-  id
+  id,
+  color
 }: {
   title: string;
   id: UniqueIdentifier;
+  color?: string;
 }) {
   const [name, setName] = React.useState(title);
+  const [currentColor, setCurrentColor] = React.useState(color || '#64748b');
   const updateCol = useTaskStore((state) => state.updateCol);
   const removeCol = useTaskStore((state) => state.removeCol);
   const [editDisable, setIsEditDisable] = React.useState(true);
   const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
+  const [showColorPicker, setShowColorPicker] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   return (
@@ -44,17 +49,35 @@ export function ColumnActions({
         onSubmit={(e) => {
           e.preventDefault();
           setIsEditDisable(!editDisable);
-          updateCol(id, name);
+          setShowColorPicker(false);
+          updateCol(id, name, currentColor);
           toast(`${title} updated to ${name}`);
         }}
       >
-        <Input
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          className='mt-0! mr-auto text-base disabled:cursor-pointer disabled:border-none disabled:opacity-100'
-          disabled={editDisable}
-          ref={inputRef}
-        />
+        <div className="flex items-center">
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className='mt-0! mr-auto text-base disabled:cursor-pointer disabled:border-none disabled:opacity-100'
+            disabled={editDisable}
+            ref={inputRef}
+          />
+          {!editDisable && (
+            <div 
+              className="w-5 h-5 ml-2 rounded-full cursor-pointer"
+              style={{ backgroundColor: currentColor }}
+              onClick={() => setShowColorPicker(!showColorPicker)}
+            />
+          )}
+        </div>
+        {showColorPicker && !editDisable && (
+          <div className="absolute z-50 mt-2 p-2 bg-background rounded-md shadow-lg border">
+            <ColorPicker 
+              selectedColor={currentColor}
+              onColorChange={setCurrentColor}
+            />
+          </div>
+        )}
       </form>
       <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
@@ -73,6 +96,14 @@ export function ColumnActions({
             }}
           >
             Rename
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => {
+              setIsEditDisable(false);
+              setShowColorPicker(true);
+            }}
+          >
+            Change Color
           </DropdownMenuItem>
           <DropdownMenuSeparator />
 

--- a/src/features/kanban/components/new-section-dialog.tsx
+++ b/src/features/kanban/components/new-section-dialog.tsx
@@ -10,11 +10,13 @@ import {
   DialogTrigger
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-
+import { useState } from 'react';
 import { useTaskStore } from '../utils/store';
+import { ColorPicker } from './color-picker';
 
 export default function NewSectionDialog() {
   const addCol = useTaskStore((state) => state.addCol);
+  const [selectedColor, setSelectedColor] = useState('#2563eb'); // Default blue color
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -24,7 +26,7 @@ export default function NewSectionDialog() {
     const { title } = Object.fromEntries(formData);
 
     if (typeof title !== 'string') return;
-    addCol(title);
+    addCol(title, selectedColor);
   };
 
   return (
@@ -52,6 +54,13 @@ export default function NewSectionDialog() {
               name='title'
               placeholder='Section title...'
               className='col-span-4'
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium mb-2 block">Section Color</label>
+            <ColorPicker 
+              selectedColor={selectedColor}
+              onColorChange={setSelectedColor}
             />
           </div>
         </form>

--- a/src/features/kanban/utils/store.ts
+++ b/src/features/kanban/utils/store.ts
@@ -4,12 +4,23 @@ import { persist } from 'zustand/middleware';
 import { UniqueIdentifier } from '@dnd-kit/core';
 import { Column } from '../components/board-column';
 
-export type Status = 'TODO' | 'IN_PROGRESS' | 'DONE';
+export type Status = string;
 
 const defaultCols = [
   {
     id: 'TODO' as const,
-    title: 'Todo'
+    title: 'Todo',
+    color: '#2563eb' // Blue
+  },
+  {
+    id: 'IN_PROGRESS' as const,
+    title: 'In Progress',
+    color: '#ca8a04' // Amber
+  },
+  {
+    id: 'DONE' as const,
+    title: 'Done',
+    color: '#16a34a' // Green
   }
 ] satisfies Column[];
 
@@ -38,18 +49,28 @@ const initialTasks: Task[] = [
     id: 'task2',
     status: 'TODO',
     title: 'Gather requirements from stakeholders'
+  },
+  {
+    id: 'task3',
+    status: 'IN_PROGRESS',
+    title: 'Design system architecture'
+  },
+  {
+    id: 'task4',
+    status: 'DONE',
+    title: 'Set up development environment'
   }
 ];
 
 export type Actions = {
   addTask: (title: string, description?: string) => void;
-  addCol: (title: string) => void;
+  addCol: (title: string, color?: string) => void;
   dragTask: (id: string | null) => void;
   removeTask: (title: string) => void;
   removeCol: (id: UniqueIdentifier) => void;
   setTasks: (updatedTask: Task[]) => void;
   setCols: (cols: Column[]) => void;
-  updateCol: (id: UniqueIdentifier, newName: string) => void;
+  updateCol: (id: UniqueIdentifier, newName: string, color?: string) => void;
 };
 
 export const useTaskStore = create<State & Actions>()(
@@ -65,17 +86,25 @@ export const useTaskStore = create<State & Actions>()(
             { id: uuid(), title, description, status: 'TODO' }
           ]
         })),
-      updateCol: (id: UniqueIdentifier, newName: string) =>
+      updateCol: (id: UniqueIdentifier, newName: string, color?: string) =>
         set((state) => ({
           columns: state.columns.map((col) =>
-            col.id === id ? { ...col, title: newName } : col
+            col.id === id ? { 
+              ...col, 
+              title: newName,
+              ...(color && { color })
+            } : col
           )
         })),
-      addCol: (title: string) =>
+      addCol: (title: string, color?: string) =>
         set((state) => ({
           columns: [
             ...state.columns,
-            { title, id: state.columns.length ? title.toUpperCase() : 'TODO' }
+            { 
+              title, 
+              id: state.columns.length ? title.toUpperCase() : 'TODO',
+              color: color || '#64748b' // Default slate color if none provided
+            }
           ]
         })),
       dragTask: (id: string | null) => set({ draggedTask: id }),


### PR DESCRIPTION
This PR resolves issue #7 by implementing multiple Kanban sections with color variations.

## Changes

1. Added three default Kanban sections (Todo, In Progress, Done) with distinct colors
2. Enhanced the Column interface to include a color property
3. Created a color picker component for selecting column colors
4. Updated the section creation dialog to allow users to select a color when adding a new section
5. Added color editing functionality to existing columns
6. Applied visual styling to distinguish columns by their colors:
   - Colored top border for each column
   - Colored bottom border for column headers
7. Added sample tasks distributed across the different sections

## Visual Changes
- Each column now has a distinct color that visually identifies its purpose
- Users can customize colors when creating new sections
- Existing sections can have their colors changed via the dropdown menu

## Screenshots
N/A - Please review the implementation directly

Closes #7